### PR TITLE
Sp3 converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ Tests/automatic_testfonts_varlib
 Tests/automatic_testfonts_varlib_defcon
 Tests/automatic_testfonts_varlib_fontparts
 Tests/automatic_testfonts*
+test*.designspace
+test*.sp3

--- a/Lib/ufoProcessor/sp3.py
+++ b/Lib/ufoProcessor/sp3.py
@@ -1,4 +1,6 @@
 import os
+import glob
+
 from fontTools.misc.loggingTools import LogMixin
 from fontTools.designspaceLib import DesignSpaceDocument, AxisDescriptor, SourceDescriptor, RuleDescriptor, InstanceDescriptor
 
@@ -12,8 +14,47 @@ except ImportError:
 # For now I just want to migrate data out of Superpolator into designspace.
 # So not all data will migrate, just the stuff we can use. 
 
+"""
+
+
+  <lib>
+    <dict>
+      <key>com.letterror.skateboard.interactionSources</key>
+      <dict>
+        <key>horizontal</key>
+        <array/>
+        <key>ignore</key>
+        <array/>
+        <key>vertical</key>
+        <array/>
+      </dict>
+      <key>com.letterror.skateboard.mutedSources</key>
+      <array>
+        <array>
+          <string>IBM Plex Sans Condensed-Bold.ufo</string>
+          <string>foreground</string>
+        </array>
+      </array>
+      <key>com.letterror.skateboard.previewLocation</key>
+      <dict>
+        <key>weight</key>
+        <real>0.0</real>
+      </dict>
+      <key>com.letterror.skateboard.previewText</key>
+      <string>SKATE</string>
+    </dict>
+  </lib>
+
+
+
+"""
 
 superpolatorDataLibKey = "com.superpolator.data"    # lib key for Sp data in .designspace
+skateboardInteractionSourcesKey = "com.letterror.skateboard.interactionSources"
+skateboardMutedSourcesKey = "com.letterror.skateboard.mutedSources"
+skipExportKey = "public.skipExportGlyphs"
+skateboardPreviewLocationsKey = "com.letterror.skateboard.previewLocation"
+skateboardPreviewTextKey = "com.letterror.skateboard.previewText"
 
 class SuperpolatorReader(LogMixin):
     ruleDescriptorClass = RuleDescriptor
@@ -21,9 +62,11 @@ class SuperpolatorReader(LogMixin):
     sourceDescriptorClass = SourceDescriptor
     instanceDescriptorClass = InstanceDescriptor
 
-    def __init__(self, documentPath, documentObject):
+    def __init__(self, documentPath, documentObject, convertRules=True, convertData=True):
         self.path = documentPath
         self.documentObject = documentObject
+        self.convertRules = convertRules
+        self.convertData = convertData
         tree = ET.parse(self.path)
         self.root = tree.getroot()
         self.documentObject.formatVersion = self.root.attrib.get("format", "3.0")
@@ -39,18 +82,31 @@ class SuperpolatorReader(LogMixin):
 
     def read(self):
         self.readAxes()
-        self.readData()
-        self.readRules()
+        if self.convertData:
+            self.readData()
+        if self.convertRules:
+            self.readOldRules()
+            self.readSimpleRules()
         self.readSources()
         self.readInstances()
 
     def readData(self):
         # read superpolator specific data, view prefs etc.
+        # if possible convert it to skateboard
+        interactionSources = {'horizontal': [], 'vertical': [], 'ignore': []}
+        ignoreElements = self.root.findall(".ignore")
+        ignoreGlyphs = []
+        for ignoreElement in ignoreElements:
+            names = ignoreElement.attrib.get('glyphs')
+            if names:
+                ignoreGlyphs = names.split(",")
+        if ignoreGlyphs:
+            self.documentObject.lib[skipExportKey] = ignoreGlyphs
         dataElements = self.root.findall(".data")
         if not dataElements:
             return
-
         newLib = {}
+        interactionSourcesAdded = False
         for dataElement in dataElements:
             name = dataElement.attrib.get('name')
             value = dataElement.attrib.get('value')
@@ -61,20 +117,104 @@ class SuperpolatorReader(LogMixin):
                     value = float(value)
                 except ValueError:
                     pass
+            if name == "previewtext":
+                self.documentObject.lib[skateboardPreviewTextKey] = value
+            elif name == "horizontalPreviewAxis":
+                interactionSources['horizontal'].append(value)
+                interactionSourcesAdded = True
+            elif name == "verticalPreviewAxis":
+                interactionSources['vertical'].append(value)
+                interactionSourcesAdded = True
+                            
             newLib[name] = value
+        if interactionSourcesAdded:
+            self.documentObject.lib[skateboardInteractionSourcesKey] = interactionSources
         if newLib:
             self.documentObject.lib[superpolatorDataLibKey] = newLib
 
-    def readRules(self):
+
+    def readOldRules(self):
+        # read the old rules
+        # <rule enabled="1" logic="all" resultfalse="B" resulttrue="B.round">
+        #   <condition axisname="AxisWidth" operator="==" xvalue="100.000000"/>
+        # </rule>
+
+        # superpolator old rule to simple rule
+        # if op in ['<', '<=']:
+        #     # old style data
+        #     axes[axisName]['maximum'] = conditionDict['values']
+        #     newRule.name = "converted %s < and <= "%(axisName)
+        # elif op in ['>', '>=']:
+        #     # old style data
+        #     axes[axisName]['minimum'] = conditionDict['values']
+        #     newRule.name = "converted %s > and >= "%(axisName)
+        # elif op == "==":
+        #     axes[axisName]['maximum'] = conditionDict['values']
+        #     axes[axisName]['minimum'] = conditionDict['values']
+        #     newRule.name = "converted %s == "%(axisName)
+        #     newRule.enabled = False
+        # elif op == "!=":
+        #     axes[axisName]['maximum'] = conditionDict['values']
+        #     axes[axisName]['minimum'] = conditionDict['values']
+        #     newRule.name = "unsupported %s != "%(axisName)
+        #     newRule.enabled = False
+        # else:
+        #     axes[axisName]['maximum'] = conditionDict['minimum']
+        #     axes[axisName]['minimum'] = conditionDict['maximum']
+        #     newRule.name = "minmax legacy rule for %s"%axisName
+        #     newRule.enabled = False
+
+        rules = []
+        for oldRuleElement in self.root.findall(".rule"):
+            ruleObject = self.ruleDescriptorClass()
+            # only one condition set in these old rules
+            cds = []
+            a = oldRuleElement.attrib['resultfalse']
+            b = oldRuleElement.attrib['resulttrue']
+            ruleObject.subs.append((a,b))
+            for oldConditionElement in oldRuleElement.findall(".condition"):
+                cd = {}
+                operator = oldConditionElement.attrib['operator']
+                axisValue = float(oldConditionElement.attrib['xvalue'])
+                axisName = oldConditionElement.attrib['axisname']
+                if operator in ['<', '<=']:
+                    cd['maximum'] = axisValue
+                    cd['minimum'] = None
+                    cd['name'] = axisName
+                    ruleObject.name = "converted %s < and <= "%(axisName)
+                elif operator in ['>', '>=']:
+                    cd['maximum'] = None
+                    cd['minimum'] = axisValue
+                    cd['name'] = axisName
+                    ruleObject.name = "converted %s > and >= "%(axisName)
+                elif operator in ["==", "!="]:
+                    # can't convert this one
+                    continue
+                cds.append(cd)
+            if cds:
+                print("oldRuleElement", axisName, operator, oldRuleElement.attrib.items())
+                print('cds',cds)
+                ruleObject.conditionSets.append(cds)
+                self.documentObject.addRule(ruleObject)
+
+    def readSimpleRules(self):
         # read the simple rule elements
+        # <simplerules>
+        #     <simplerule enabled="1" name="width: &lt; 500.0">
+        #         <sub name="I" with="I.narrow"/>
+        #         <condition axisname="width" maximum="500"/>
+        #         <condition axisname="grade" minimum="0" maximum="500"/>
+        #     </simplerule>
+        # </simplerules>
+
+
         rulesContainerElements = self.root.findall(".simplerules")
-        print('rulesContainerElements', rulesContainerElements)
+        #print('rulesContainerElements', rulesContainerElements)
         rules = []
         for rulesContainerElement in rulesContainerElements:
             for ruleElement in rulesContainerElement:
                 ruleObject = self.ruleDescriptorClass()
                 ruleName = ruleObject.name = ruleElement.attrib['name']
-                print('rule', ruleName)
                 # subs
                 for subElement in ruleElement.findall('.sub'):
                     a = subElement.attrib['name']
@@ -85,16 +225,13 @@ class SuperpolatorReader(LogMixin):
                     ruleElement,
                     ruleName,
                 )
-                print("externalConditions", externalConditions)
                 if externalConditions:
                     ruleObject.conditionSets.append(externalConditions)
                     self.log.info(
                         "Found stray rule conditions outside a conditionset. "
                         "Wrapped them in a new conditionset."
                     )
-            print("ruleObject.name", ruleObject.name)
-            rules.append(ruleObject)
-        self.documentObject.rules = rules
+                self.documentObject.addRule(ruleObject)
 
     def _readConditionElements(self, parentElement, ruleName=None):
         # modified from the method from fonttools.designspaceLib
@@ -121,6 +258,7 @@ class SuperpolatorReader(LogMixin):
                     "condition missing required minimum or maximum in rule" +
                     (" '%s'" % ruleName if ruleName is not None else ""))
             cds.append(cd)
+        print('\t\t_readConditionElements', cds)
         return cds
 
     def readAxes(self):
@@ -128,7 +266,6 @@ class SuperpolatorReader(LogMixin):
         axisElements = self.root.findall(".axis")
         if not axisElements:
             # raise error, we need axes
-            print("nope")
             return
         for axisElement in axisElements:
             axisObject = self.axisDescriptorClass()
@@ -208,6 +345,11 @@ class SuperpolatorReader(LogMixin):
             if styleName is not None:
                 sourceObject.styleName = styleName
             sourceObject.location = self.locationFromElement(sourceElement)
+            isMuted = False
+            for maskedElement in sourceElement.findall('.maskedfont'):
+                # mute isn't stored in the sourceDescriptor, but we can store it in the lib
+                if maskedElement.attrib.get('font') == "1":
+                    isMuted = True
             for libElement in sourceElement.findall('.provideLib'):
                 if libElement.attrib.get('state') == '1':
                     sourceObject.copyLib = True
@@ -227,6 +369,11 @@ class SuperpolatorReader(LogMixin):
                 if glyphElement.attrib.get('mute') == '1':
                     sourceObject.mutedGlyphNames.append(glyphName)
             self.documentObject.sources.append(sourceObject)
+            if isMuted:
+                if not skateboardMutedSourcesKey in self.documentObject.lib:
+                    self.documentObject.lib[skateboardMutedSourcesKey] = []
+                item = (sourceObject.filename, "foreground")
+                self.documentObject.lib[skateboardMutedSourcesKey].append(item)
 
     def readInstances(self):
         for instanceCount, instanceElement in enumerate(self.root.findall(".instance")):
@@ -251,72 +398,93 @@ class SuperpolatorReader(LogMixin):
                     instanceObject.info = True
             self.documentObject.instances.append(instanceObject)
 
-if __name__ == "__main__":
-    testDoc = DesignSpaceDocument()
-    testPath = "../../Tests/spReader_testdocs/superpolator_testdoc1.sp3"
-    reader = SuperpolatorReader(testPath, testDoc)
+def sp3_to_designspace(sp3path, designspacePath=None):
+    if designspacePath is None:
+        designspacePath = sp3path.replace(".sp3", ".designspace")
+    doc = DesignSpaceDocument()
+    reader = SuperpolatorReader(sp3path, doc)
     reader.read()
-
-    # check the axes
-    names = [a.name for a in reader.documentObject.axes]
-    names.sort()
-    assert names == ['grade', 'space', 'weight', 'width']
-    tags = [a.tag for a in reader.documentObject.axes]
-    tags.sort()
-    assert tags == ['SPCE', 'grad', 'wdth', 'wght']
-
-    # check the data items
-    assert superpolatorDataLibKey in reader.documentObject.lib
-    items = list(reader.documentObject.lib[superpolatorDataLibKey].items())
-    items.sort()
-    assert items == [('expandRules', False), ('horizontalPreviewAxis', 'width'), ('includeLegacyRules', False), ('instancefolder', 'instances'), ('keepWorkFiles', True), ('lineInverted', True), ('lineStacked', 'lined'), ('lineViewFilled', True), ('outputFormatUFO', 3.0), ('previewtext', 'VA'), ('roundGeometry', False), ('verticalPreviewAxis', 'weight')]
-
-    # check the sources
-    print("reader.documentObject.sources: %d items" % len(reader.documentObject.sources))
-    for sd in reader.documentObject.sources:
-        assert sd.familyName == "MutatorMathTest_SourceFamilyName"
-        if sd.styleName == "Default":
-            assert sd.location == {'width': 0.0, 'weight': 0.0, 'space': 0.0, 'grade': -0.5}
-            assert sd.copyLib == True
-            assert sd.copyGroups == True
-            assert sd.copyInfo == True
-            assert sd.copyFeatures == True
-        elif sd.styleName == "TheOther":
-            assert sd.location == {'width': 0.0, 'weight': 1000.0, 'space': 0.0, 'grade': -0.5}
-            assert sd.copyLib == False
-            assert sd.copyGroups == False
-            assert sd.copyInfo == False
-            assert sd.copyFeatures == False
-
-    # check the instances
-    print("reader.documentObject.instances: %d items" % len(reader.documentObject.instances))
-    for nd in reader.documentObject.instances:
-        assert nd.familyName == "MutatorMathTest_InstanceFamilyName"
-        if nd.styleName == "AWeightThatILike":
-            assert nd.location == {'width': 133.152174, 'weight': 723.981097, 'space': 0.0, 'grade': -0.5}
-            assert nd.filename == "instances/MutatorMathTest_InstanceFamilyName-AWeightThatILike.ufo"
-            assert nd.styleMapFamilyName == None
-            assert nd.styleMapStyleName == None
-        if nd.styleName == "wdth759.79_SPCE0.00_wght260.72":
-            # note the anisotropic location in the width axis.
-            assert nd.location == {'width': (500.0, 800.0), 'weight': 260.7217, 'space': 0.0, 'grade': -0.5}
-            assert nd.filename == "instances/MutatorMathTest_InstanceFamilyName-wdth759.79_SPCE0.00_wght260.72.ufo"
-            assert nd.styleMapFamilyName == "StyleMappedFamily"
-            assert nd.styleMapStyleName == "bold"
-
-    # check the rules
-    for rd in reader.documentObject.rules:
-        assert rd.name == "width: < 500.0"
-        assert len(rd.conditionSets) == 1
-        assert rd.subs == [('I', 'I.narrow')]
-        for conditionSet in rd.conditionSets:
-            for cd in conditionSet:
-                print(cd)
-                if cd['name'] == "width":
-                    assert cd == {'minimum': None, 'maximum': 500.0, 'name': 'width'}
-                if cd['name'] == "grade":
-                    assert cd == {'minimum': 0.0, 'maximum': 500.0, 'name': 'grade'}
+    doc.write(designspacePath)
 
 
-    testDoc.write(testPath.replace(".sp3", "_output_roundtripped.designspace"))
+if __name__ == "__main__":
 
+    def test_superpolator_testdoc1():
+        # read superpolator_testdoc1.sp3
+        # and test all the values
+        testDoc = DesignSpaceDocument()
+        testPath = "../../Tests/spReader_testdocs/superpolator_testdoc1.sp3"
+        reader = SuperpolatorReader(testPath, testDoc)
+        reader.read()
+
+        # check the axes
+        names = [a.name for a in reader.documentObject.axes]
+        names.sort()
+        assert names == ['grade', 'space', 'weight', 'width']
+        tags = [a.tag for a in reader.documentObject.axes]
+        tags.sort()
+        assert tags == ['SPCE', 'grad', 'wdth', 'wght']
+
+        # check the data items
+        assert superpolatorDataLibKey in reader.documentObject.lib
+        items = list(reader.documentObject.lib[superpolatorDataLibKey].items())
+        items.sort()
+        assert items == [('expandRules', False), ('horizontalPreviewAxis', 'width'), ('includeLegacyRules', False), ('instancefolder', 'instances'), ('keepWorkFiles', True), ('lineInverted', True), ('lineStacked', 'lined'), ('lineViewFilled', True), ('outputFormatUFO', 3.0), ('previewtext', 'VA'), ('roundGeometry', False), ('verticalPreviewAxis', 'weight')]
+
+        # check the sources
+        print("reader.documentObject.sources: %d items" % len(reader.documentObject.sources))
+        for sd in reader.documentObject.sources:
+            assert sd.familyName == "MutatorMathTest_SourceFamilyName"
+            if sd.styleName == "Default":
+                assert sd.location == {'width': 0.0, 'weight': 0.0, 'space': 0.0, 'grade': -0.5}
+                assert sd.copyLib == True
+                assert sd.copyGroups == True
+                assert sd.copyInfo == True
+                assert sd.copyFeatures == True
+            elif sd.styleName == "TheOther":
+                assert sd.location == {'width': 0.0, 'weight': 1000.0, 'space': 0.0, 'grade': -0.5}
+                assert sd.copyLib == False
+                assert sd.copyGroups == False
+                assert sd.copyInfo == False
+                assert sd.copyFeatures == False
+
+        # check the instances
+        print("reader.documentObject.instances: %d items" % len(reader.documentObject.instances))
+        for nd in reader.documentObject.instances:
+            assert nd.familyName == "MutatorMathTest_InstanceFamilyName"
+            if nd.styleName == "AWeightThatILike":
+                assert nd.location == {'width': 133.152174, 'weight': 723.981097, 'space': 0.0, 'grade': -0.5}
+                assert nd.filename == "instances/MutatorMathTest_InstanceFamilyName-AWeightThatILike.ufo"
+                assert nd.styleMapFamilyName == None
+                assert nd.styleMapStyleName == None
+            if nd.styleName == "wdth759.79_SPCE0.00_wght260.72":
+                # note the anisotropic location in the width axis.
+                assert nd.location == {'width': (500.0, 800.0), 'weight': 260.7217, 'space': 0.0, 'grade': -0.5}
+                assert nd.filename == "instances/MutatorMathTest_InstanceFamilyName-wdth759.79_SPCE0.00_wght260.72.ufo"
+                assert nd.styleMapFamilyName == "StyleMappedFamily"
+                assert nd.styleMapStyleName == "bold"
+
+        # check the rules
+        for rd in reader.documentObject.rules:
+            assert rd.name == "width: < 500.0"
+            assert len(rd.conditionSets) == 1
+            assert rd.subs == [('I', 'I.narrow')]
+            for conditionSet in rd.conditionSets:
+                for cd in conditionSet:
+                    if cd['name'] == "width":
+                        assert cd == {'minimum': None, 'maximum': 500.0, 'name': 'width'}
+                    if cd['name'] == "grade":
+                        assert cd == {'minimum': 0.0, 'maximum': 500.0, 'name': 'grade'}
+
+
+        testDoc.write(testPath.replace(".sp3", "_output_roundtripped.designspace"))
+
+    def test_testDocs():
+        # read the test files and convert them
+        # no tests
+        root = "../../Tests/spReader_testdocs/test*.sp3"
+        for path in glob.glob(root):
+            print("----", path)
+            sp3_to_designspace(path)
+
+    test_testDocs()

--- a/Lib/ufoProcessor/sp3.py
+++ b/Lib/ufoProcessor/sp3.py
@@ -1,0 +1,284 @@
+import os
+from fontTools.misc.loggingTools import LogMixin
+from fontTools.designspaceLib import DesignSpaceDocument, AxisDescriptor, SourceDescriptor, RuleDescriptor, InstanceDescriptor
+
+try:
+    import xml.etree.cElementTree as ET
+except ImportError:
+    import xml.etree.ElementTree as ET
+
+# Reader that parses Superpolator documents and buidls designspace objects.
+# Note: the Superpolator document format precedes the designspace documnt format.
+# For now I just want to migrate data out of Superpolator into designspace.
+# So not all data will migrate, just the stuff we can use. 
+
+
+superpolatorDataLibKey = "com.superpolator.data"    # lib key for Sp data in .designspace
+
+class SuperpolatorReader(LogMixin):
+    ruleDescriptorClass = RuleDescriptor
+    axisDescriptorClass = AxisDescriptor
+    sourceDescriptorClass = SourceDescriptor
+    instanceDescriptorClass = InstanceDescriptor
+
+    def __init__(self, documentPath, documentObject):
+        self.path = documentPath
+        self.documentObject = documentObject
+        tree = ET.parse(self.path)
+        self.root = tree.getroot()
+        self.documentObject.formatVersion = self.root.attrib.get("format", "3.0")
+        #self._axes = []
+        #self.rules = []
+        #self.sources = []
+        #self.instances = []
+        self.axisDefaults = {}
+        self._strictAxisNames = True
+        print(tree)
+
+    @classmethod
+    def fromstring(cls, string, documentObject):
+        f = BytesIO(tobytes(string, encoding="utf-8"))
+        self = cls(f, documentObject)
+        self.path = None
+        return self
+
+    def read(self):
+        self.readAxes()
+        self.readData()
+        self.readRules()
+        self.readSources()
+        self.readInstances()
+        #self.readLib()
+
+    def readData(self):
+        # read superpolator specific data, view prefs etc.
+        dataElements = self.root.findall(".data")
+        if not dataElements:
+            return
+
+        newLib = {}
+        for dataElement in dataElements:
+            name = dataElement.attrib.get('name')
+            value = dataElement.attrib.get('value')
+            if value in ['True', 'False']:
+                value = value == "True"
+            else:
+                try:
+                    value = float(value)
+                except ValueError:
+                    pass
+            newLib[name] = value
+        if newLib:
+            self.documentObject.lib[superpolatorDataLibKey] = newLib
+
+
+    def readRules(self):
+        # read the simple rule elements
+        pass
+
+    def readAxes(self):
+        # read the axes elements, including the warp map.
+        axisElements = self.root.findall(".axis")
+        if not axisElements:
+            # raise error, we need axes
+            print("nope")
+            return
+        for axisElement in axisElements:
+            axisObject = self.axisDescriptorClass()
+            axisObject.name = axisElement.attrib.get("name")
+            axisObject.tag = axisElement.attrib.get("shortname")
+            print("zz", axisObject.tag)
+            axisObject.minimum = float(axisElement.attrib.get("minimum"))
+            axisObject.maximum = float(axisElement.attrib.get("maximum"))
+            #if axisElement.attrib.get('hidden', False):
+            #    axisObject.hidden = True
+            axisObject.default = float(axisElement.attrib.get("initialvalue", axisObject.minimum))
+        #     for mapElement in axisElement.findall('map'):
+        #         a = float(mapElement.attrib['input'])
+        #         b = float(mapElement.attrib['output'])
+        #         axisObject.map.append((a, b))
+        #     for labelNameElement in axisElement.findall('labelname'):
+        #         # Note: elementtree reads the xml:lang attribute name as
+        #         # '{http://www.w3.org/XML/1998/namespace}lang'
+        #         for key, lang in labelNameElement.items():
+        #             if key == XML_LANG:
+        #                 labelName = labelNameElement.text
+        #                 axisObject.labelNames[lang] = labelName
+            print(axisObject.serialize())
+            self.documentObject.axes.append(axisObject)
+            self.axisDefaults[axisObject.name] = axisObject.default
+        self.documentObject.defaultLoc = self.axisDefaults
+        print("self.documentObject.defaultLoc", self.documentObject.defaultLoc)
+
+    def colorFromElement(self, element):
+        elementColor = None
+        for colorElement in element.findall('.color'):
+            elementColor = self.readColorElement(colorElement)
+
+    def readColorElement(self, colorElement):
+        print("colorElement", colorElement)
+        pass
+
+    def locationFromElement(self, element):
+        elementLocation = None
+        for locationElement in element.findall('.location'):
+            elementLocation = self.readLocationElement(locationElement)
+            break
+        return elementLocation
+
+    def readLocationElement(self, locationElement):
+        """ Format 0 location reader """
+        if self._strictAxisNames and not self.documentObject.axes:
+            raise DesignSpaceDocumentError("No axes defined")
+        loc = {}
+        for dimensionElement in locationElement.findall(".dimension"):
+            dimName = dimensionElement.attrib.get("name")
+            if self._strictAxisNames and dimName not in self.axisDefaults:
+                # In case the document contains no axis definitions,
+                self.log.warning("Location with undefined axis: \"%s\".", dimName)
+                continue
+            xValue = yValue = None
+            try:
+                xValue = dimensionElement.attrib.get('xvalue')
+                xValue = float(xValue)
+            except ValueError:
+                self.log.warning("KeyError in readLocation xValue %3.3f", xValue)
+            try:
+                yValue = dimensionElement.attrib.get('yvalue')
+                if yValue is not None:
+                    yValue = float(yValue)
+            except ValueError:
+                pass
+            if yValue is not None:
+                loc[dimName] = (xValue, yValue)
+            else:
+                loc[dimName] = xValue
+        return loc
+
+    def readSources(self):
+        for sourceCount, sourceElement in enumerate(self.root.findall(".master")):
+            filename = sourceElement.attrib.get('filename')
+            if filename is not None and self.path is not None:
+                sourcePath = os.path.abspath(os.path.join(os.path.dirname(self.path), filename))
+            else:
+                sourcePath = None
+            sourceName = sourceElement.attrib.get('name')
+            if sourceName is None:
+                # add a temporary source name
+                sourceName = "temp_master.%d" % (sourceCount)
+            sourceObject = self.sourceDescriptorClass()
+            sourceObject.path = sourcePath        # absolute path to the ufo source
+            sourceObject.filename = filename      # path as it is stored in the document
+            sourceObject.name = sourceName
+            familyName = sourceElement.attrib.get("familyname")
+            if familyName is not None:
+                sourceObject.familyName = familyName
+            styleName = sourceElement.attrib.get("stylename")
+            if styleName is not None:
+                sourceObject.styleName = styleName
+            sourceObject.location = self.locationFromElement(sourceElement)
+            # layerName = sourceElement.attrib.get('layer')
+            # if layerName is not None:
+            #     sourceObject.layerName = layerName
+            for libElement in sourceElement.findall('.provideLib'):
+                if libElement.attrib.get('state') == '1':
+                    sourceObject.copyLib = True
+            for groupsElement in sourceElement.findall('.provideGroups'):
+                if groupsElement.attrib.get('state') == '1':
+                    sourceObject.copyGroups = True
+            for infoElement in sourceElement.findall(".provideInfo"):
+                if infoElement.attrib.get('state') == '1':
+                    sourceObject.copyInfo = True
+            #     if infoElement.attrib.get('mute') == '1':
+            #         sourceObject.muteInfo = True
+            for featuresElement in sourceElement.findall(".provideFeatures"):
+                if featuresElement.attrib.get('state') == '1':
+                    sourceObject.copyFeatures = True
+            for glyphElement in sourceElement.findall(".glyph"):
+                glyphName = glyphElement.attrib.get('name')
+                if glyphName is None:
+                    continue
+                if glyphElement.attrib.get('mute') == '1':
+                    sourceObject.mutedGlyphNames.append(glyphName)
+            # for kerningElement in sourceElement.findall(".kerning"):
+            #     if kerningElement.attrib.get('mute') == '1':
+            #         sourceObject.muteKerning = True
+            # self.documentObject.sources.append(sourceObject)
+            
+            #print("sourceName", sourceName)
+            #print("\tsourcePath", sourcePath)
+            #print("\tsourceObject.styleName", sourceObject.styleName)
+            #print("\tsourceObject.familyName", sourceObject.familyName)
+            #print("\tsourceObject.location", sourceObject.location)
+            #print("\tsourceObject.copyLib", sourceObject.copyLib)
+            #print("\tsourceObject.copyGroups", sourceObject.copyGroups)
+            self.documentObject.sources.append(sourceObject)
+
+    def readInstances(self):
+        for instanceCount, instanceElement in enumerate(self.root.findall(".instance")):
+            instanceObject = self.instanceDescriptorClass()
+            instanceObject.familyName = instanceElement.attrib.get("familyname")
+            instanceObject.styleName = instanceElement.attrib.get("stylename")
+            instanceObject.location = self.locationFromElement(instanceElement)
+            instanceObject.filename = instanceElement.attrib.get('filename')
+
+            for libElement in instanceObject.findall('.provideLib'):
+                if libElement.attrib.get('state') == '1':
+                    instanceObject.copyLib = True
+            self.documentObject.instances.append(instanceObject)
+
+if __name__ == "__main__":
+    testDoc = DesignSpaceDocument()
+    testPath = "../../Tests/spReader_testdocs/superpolator_testdoc1.sp3"
+    reader = SuperpolatorReader(testPath, testDoc)
+    reader.read()
+
+    # get the axes
+    names = [a.name for a in reader.documentObject.axes]
+    names.sort()
+    assert names == ['grade', 'space', 'weight', 'width']
+    tags = [a.tag for a in reader.documentObject.axes]
+    tags.sort()
+    assert tags == ['SPCE', 'grad', 'wdth', 'wght']
+
+
+    # get the data items
+    assert superpolatorDataLibKey in reader.documentObject.lib
+    items = list(reader.documentObject.lib[superpolatorDataLibKey].items())
+    items.sort()
+    assert items == [('expandRules', False), ('horizontalPreviewAxis', 'width'), ('includeLegacyRules', False), ('instancefolder', 'instances'), ('keepWorkFiles', True), ('lineInverted', True), ('lineStacked', 'lined'), ('lineViewFilled', True), ('outputFormatUFO', 3.0), ('previewtext', 'VA'), ('roundGeometry', False), ('verticalPreviewAxis', 'weight')]
+
+    # get the sources
+    print("reader.documentObject.sources: %d items" % len(reader.documentObject.sources))
+    for sd in reader.documentObject.sources:
+        assert sd.familyName == "MutatorMathTest_SourceFamilyName"
+        if sd.styleName == "Default":
+            assert sd.location == {'width': 0.0, 'weight': 0.0, 'space': 0.0, 'grade': -0.5}
+            assert sd.copyLib == True
+            assert sd.copyGroups == True
+            assert sd.copyInfo == True
+            assert sd.copyFeatures == True
+        elif sd.styleName == "TheOther":
+            assert sd.location == {'width': 0.0, 'weight': 1000.0, 'space': 0.0, 'grade': -0.5}
+            assert sd.copyLib == False
+            assert sd.copyGroups == False
+            assert sd.copyInfo == False
+            assert sd.copyFeatures == False
+
+    # get the instances
+    print("reader.documentObject.instances: %d items" % len(reader.documentObject.instances))
+    for nd in reader.documentObject.instances:
+        assert nd.familyName == "MutatorMathTest_InstanceFamilyName"
+        if nd.styleName == "AWeightThatILike":
+            assert nd.location == {'width': 133.152174, 'weight': 723.981097, 'space': 0.0, 'grade': -0.5}
+            assert nd.filename == "instances/MutatorMathTest-AWeightThatILike.ufo"
+        if nd.styleName == "wdth759.79_SPCE0.00_wght260.72":
+            # note the anisotropic location in the width axis.
+            assert nd.location == {'width': (500.0, 800.0), 'weight': 260.7217, 'space': 0.0, 'grade': -0.5}
+            assert nd.filename =="instances/MutatorMathTest-wdth759.79_SPCE0.00_wght260.72.ufo"
+        print(nd.filename)
+
+
+
+    #testDoc.write(path.replace(".sp3", "_roundtripped.designspace"))
+

--- a/Lib/ufoProcessor/sp3.py
+++ b/Lib/ufoProcessor/sp3.py
@@ -217,14 +217,23 @@ class SuperpolatorReader(LogMixin):
     def readInstances(self):
         for instanceCount, instanceElement in enumerate(self.root.findall(".instance")):
             instanceObject = self.instanceDescriptorClass()
-            instanceObject.familyName = instanceElement.attrib.get("familyname")
-            instanceObject.styleName = instanceElement.attrib.get("stylename")
+            if instanceElement.attrib.get("familyname"):
+                instanceObject.setFamilyName(instanceElement.attrib.get("familyname"), "en")    # superpolator only got one language
+            if instanceElement.attrib.get("stylename"):
+                instanceObject.setStyleName(instanceElement.attrib.get("stylename"), "en")
+            if instanceElement.attrib.get("styleMapFamilyName"):
+                instanceObject.styleMapFamilyName = instanceElement.attrib.get("styleMapFamilyName")
+            if instanceElement.attrib.get("styleMapStyleName"):
+                instanceObject.styleMapStyleName = instanceElement.attrib.get("styleMapStyleName")
             instanceObject.location = self.locationFromElement(instanceElement)
             instanceObject.filename = instanceElement.attrib.get('filename')
 
-            for libElement in instanceObject.findall('.provideLib'):
+            for libElement in instanceElement.findall('.provideLib'):
                 if libElement.attrib.get('state') == '1':
-                    instanceObject.copyLib = True
+                    instanceObject.lib = True
+            for libElement in instanceElement.findall('.provideInfo'):
+                if libElement.attrib.get('state') == '1':
+                    instanceObject.info = True
             self.documentObject.instances.append(instanceObject)
 
 if __name__ == "__main__":
@@ -251,6 +260,7 @@ if __name__ == "__main__":
     # get the sources
     print("reader.documentObject.sources: %d items" % len(reader.documentObject.sources))
     for sd in reader.documentObject.sources:
+        print(sd.familyName)
         assert sd.familyName == "MutatorMathTest_SourceFamilyName"
         if sd.styleName == "Default":
             assert sd.location == {'width': 0.0, 'weight': 0.0, 'space': 0.0, 'grade': -0.5}
@@ -268,15 +278,18 @@ if __name__ == "__main__":
     # get the instances
     print("reader.documentObject.instances: %d items" % len(reader.documentObject.instances))
     for nd in reader.documentObject.instances:
-        assert nd.familyName == "MutatorMathTest_InstanceFamilyName"
+        assert nd.getFamilyName() == "MutatorMathTest_InstanceFamilyName"
         if nd.styleName == "AWeightThatILike":
             assert nd.location == {'width': 133.152174, 'weight': 723.981097, 'space': 0.0, 'grade': -0.5}
             assert nd.filename == "instances/MutatorMathTest-AWeightThatILike.ufo"
-        if nd.styleName == "wdth759.79_SPCE0.00_wght260.72":
+            assert nd.styleMapFamilyName == None
+            assert nd.styleMapStyleName == None
+        if nd.getStyleName() == "wdth759.79_SPCE0.00_wght260.72":
             # note the anisotropic location in the width axis.
             assert nd.location == {'width': (500.0, 800.0), 'weight': 260.7217, 'space': 0.0, 'grade': -0.5}
-            assert nd.filename =="instances/MutatorMathTest-wdth759.79_SPCE0.00_wght260.72.ufo"
-        print(nd.filename)
+            assert nd.filename == "instances/MutatorMathTest_InstanceFamilyName-wdth759.79_SPCE0.00_wght260.72.ufo"
+            assert nd.styleMapFamilyName == "StyleMappedFamily"
+            assert nd.styleMapStyleName == "bold"
 
 
 

--- a/Tests/spReader_testdocs/superpolator_testdoc1.sp3
+++ b/Tests/spReader_testdocs/superpolator_testdoc1.sp3
@@ -4,18 +4,18 @@
     <!-- info -->
     <version superpolator="2"/>
     <!-- application data -->
-    <data name="previewtext" value="VA"/>
-    <data name="lineStacked" value="lined"/>
-    <data name="lineViewFilled" value="True"/>
-    <data name="lineInverted" value="True"/>
-    <data name="instancefolder" value="instances"/>
     <data name="horizontalPreviewAxis" value="width"/>
-    <data name="verticalPreviewAxis" value="weight"/>
-    <data name="outputFormatUFO" value="3"/>
+    <data name="roundGeometry" value="False"/>
+    <data name="lineInverted" value="True"/>
     <data name="expandRules" value="False"/>
+    <data name="lineViewFilled" value="True"/>
+    <data name="outputFormatUFO" value="3"/>
+    <data name="lineStacked" value="lined"/>
     <data name="includeLegacyRules" value="False"/>
     <data name="keepWorkFiles" value="True"/>
-    <data name="roundGeometry" value="False"/>
+    <data name="previewtext" value="VA"/>
+    <data name="instancefolder" value="instances"/>
+    <data name="verticalPreviewAxis" value="weight"/>
     <!-- don't generate these glyphs -->
     <ignore glyphs=""/>
     <!-- these are the new simple rules -->
@@ -26,6 +26,9 @@
         </simplerule>
     </simplerules>
     <!-- axis definitions -->
+    <axis maximum="1" minimum="-1" name="grade" shortname="grad">
+        <color a="1.000" b="0.821" g="0.989" r="0.160"/>
+    </axis>
     <axis maximum="1000" minimum="0" name="width" shortname="wdth">
         <color a="1.000" b="0.612" g="0.993" r="0.053"/>
     </axis>
@@ -35,17 +38,14 @@
     <axis maximum="50" minimum="0" name="space" shortname="SPCE">
         <color a="1.000" b="0.500" g="0.500" r="0.500"/>
     </axis>
-    <axis maximum="1" minimum="-1" name="grade" shortname="grad">
-        <color a="1.000" b="0.821" g="0.989" r="0.160"/>
-    </axis>
     <!-- master definitions -->
     <!-- masks -->
-    <master familyname="MutatorMathTest_SourceFamilyName" filename="ufo/MutatorSansLightCondensed.ufo" sortorder="0" stylename="Default">
+    <master familyname="MutatorMathTest_SourceFamilyName" filename="ufo/MutatorSansLightCondensed.ufo" sortorder="0" stylename="">
         <location>
+            <dimension name="grade" xvalue="-0.500000"/>
             <dimension name="width" xvalue="0"/>
             <dimension name="weight" xvalue="0"/>
             <dimension name="space" xvalue="0"/>
-            <dimension name="grade" xvalue="-0.500000"/>
         </location>
         <provideFeatures state="1"/>
         <provideGroups state="1"/>
@@ -53,40 +53,39 @@
         <provideInfo state="1"/>
         <maskedfont font="1"/>
     </master>
-
-    <master familyname="MutatorMathTest_SourceFamilyName" filename="ufo/MutatorSansBoldCondensed.ufo" sortorder="1" stylename="TheOther">
+    <!-- masks -->
+    <master familyname="MutatorMathTest_SourceFamilyName" filename="ufo/MutatorSansBoldCondensed.ufo" sortorder="1" stylename="">
         <location>
+            <dimension name="grade" xvalue="-0.500000"/>
             <dimension name="width" xvalue="0"/>
             <dimension name="weight" xvalue="1000"/>
             <dimension name="space" xvalue="0"/>
-            <dimension name="grade" xvalue="-0.500000"/>
         </location>
         <maskedfont font="1"/>
     </master>
-
     <!-- instance definitions -->
-    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest-AWeightThatILike.ufo" sortorder="4" stylename="AWeightThatILike">
+    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest_InstanceFamilyName-AWeightThatILike.ufo" sortorder="2" stylename="AWeightThatILike">
         <location>
+            <dimension name="grade" xvalue="-0.500000"/>
             <dimension name="width" xvalue="133.152174"/>
             <dimension name="weight" xvalue="723.981097"/>
             <dimension name="space" xvalue="0"/>
-            <dimension name="grade" xvalue="-0.500000"/>
         </location>
         <provideFeatures state="1"/>
         <provideGroups state="1"/>
         <provideLib state="1"/>
         <provideInfo state="1"/>
     </instance>
-    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest-wdth759.79_SPCE0.00_wght260.72.ufo" sortorder="5" stylename="wdth759.79_SPCE0.00_wght260.72">
+    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest_InstanceFamilyName-wdth759.79_SPCE0.00_wght260.72.ufo" sortorder="3" styleMapFamilyName="StyleMappedFamily" styleMapStyleName="bold" stylename="wdth759.79_SPCE0.00_wght260.72">
         <location>
+            <dimension name="grade" xvalue="-0.500000"/>
             <dimension name="width" xvalue="500" yvalue="800"/>
             <dimension name="weight" xvalue="260.721700"/>
             <dimension name="space" xvalue="0"/>
-            <dimension name="grade" xvalue="-0.500000"/>
         </location>
         <provideFeatures state="1"/>
-        <provideGroups state="0"/>
-        <provideLib state="0"/>
+        <provideGroups state="1"/>
+        <provideLib state="1"/>
         <provideInfo state="1"/>
     </instance>
 </designspace>

--- a/Tests/spReader_testdocs/superpolator_testdoc1.sp3
+++ b/Tests/spReader_testdocs/superpolator_testdoc1.sp3
@@ -23,6 +23,7 @@
         <simplerule enabled="1" name="width: &lt; 500.0">
             <sub name="I" with="I.narrow"/>
             <condition axisname="width" maximum="500"/>
+            <condition axisname="grade" minimum="0" maximum="500"/>
         </simplerule>
     </simplerules>
     <!-- axis definitions -->
@@ -64,7 +65,7 @@
         <maskedfont font="1"/>
     </master>
     <!-- instance definitions -->
-    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest_InstanceFamilyName-AWeightThatILike.ufo" sortorder="2" stylename="AWeightThatILike">
+    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest_InstanceFamilyName-AWeightThatILike.ufo" sortorder="2" stylename="AWeightThatILike" postscriptfontname="SomePostscriptName" >
         <location>
             <dimension name="grade" xvalue="-0.500000"/>
             <dimension name="width" xvalue="133.152174"/>

--- a/Tests/spReader_testdocs/superpolator_testdoc1.sp3
+++ b/Tests/spReader_testdocs/superpolator_testdoc1.sp3
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<designspace format="2">
+    <!-- Superpolator Designspace Object -->
+    <!-- info -->
+    <version superpolator="2"/>
+    <!-- application data -->
+    <data name="previewtext" value="VA"/>
+    <data name="lineStacked" value="lined"/>
+    <data name="lineViewFilled" value="True"/>
+    <data name="lineInverted" value="True"/>
+    <data name="instancefolder" value="instances"/>
+    <data name="horizontalPreviewAxis" value="width"/>
+    <data name="verticalPreviewAxis" value="weight"/>
+    <data name="outputFormatUFO" value="3"/>
+    <data name="expandRules" value="False"/>
+    <data name="includeLegacyRules" value="False"/>
+    <data name="keepWorkFiles" value="True"/>
+    <data name="roundGeometry" value="False"/>
+    <!-- don't generate these glyphs -->
+    <ignore glyphs=""/>
+    <!-- these are the new simple rules -->
+    <simplerules>
+        <simplerule enabled="1" name="width: &lt; 500.0">
+            <sub name="I" with="I.narrow"/>
+            <condition axisname="width" maximum="500"/>
+        </simplerule>
+    </simplerules>
+    <!-- axis definitions -->
+    <axis maximum="1000" minimum="0" name="width" shortname="wdth">
+        <color a="1.000" b="0.612" g="0.993" r="0.053"/>
+    </axis>
+    <axis maximum="1000" minimum="0" name="weight" shortname="wght">
+        <color a="1.000" b="0.764" g="0.000" r="0.989"/>
+    </axis>
+    <axis maximum="50" minimum="0" name="space" shortname="SPCE">
+        <color a="1.000" b="0.500" g="0.500" r="0.500"/>
+    </axis>
+    <axis maximum="1" minimum="-1" name="grade" shortname="grad">
+        <color a="1.000" b="0.821" g="0.989" r="0.160"/>
+    </axis>
+    <!-- master definitions -->
+    <!-- masks -->
+    <master familyname="MutatorMathTest_SourceFamilyName" filename="ufo/MutatorSansLightCondensed.ufo" sortorder="0" stylename="Default">
+        <location>
+            <dimension name="width" xvalue="0"/>
+            <dimension name="weight" xvalue="0"/>
+            <dimension name="space" xvalue="0"/>
+            <dimension name="grade" xvalue="-0.500000"/>
+        </location>
+        <provideFeatures state="1"/>
+        <provideGroups state="1"/>
+        <provideLib state="1"/>
+        <provideInfo state="1"/>
+        <maskedfont font="1"/>
+    </master>
+
+    <master familyname="MutatorMathTest_SourceFamilyName" filename="ufo/MutatorSansBoldCondensed.ufo" sortorder="1" stylename="TheOther">
+        <location>
+            <dimension name="width" xvalue="0"/>
+            <dimension name="weight" xvalue="1000"/>
+            <dimension name="space" xvalue="0"/>
+            <dimension name="grade" xvalue="-0.500000"/>
+        </location>
+        <maskedfont font="1"/>
+    </master>
+
+    <!-- instance definitions -->
+    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest-AWeightThatILike.ufo" sortorder="4" stylename="AWeightThatILike">
+        <location>
+            <dimension name="width" xvalue="133.152174"/>
+            <dimension name="weight" xvalue="723.981097"/>
+            <dimension name="space" xvalue="0"/>
+            <dimension name="grade" xvalue="-0.500000"/>
+        </location>
+        <provideFeatures state="1"/>
+        <provideGroups state="1"/>
+        <provideLib state="1"/>
+        <provideInfo state="1"/>
+    </instance>
+    <instance familyname="MutatorMathTest_InstanceFamilyName" filename="instances/MutatorMathTest-wdth759.79_SPCE0.00_wght260.72.ufo" sortorder="5" stylename="wdth759.79_SPCE0.00_wght260.72">
+        <location>
+            <dimension name="width" xvalue="500" yvalue="800"/>
+            <dimension name="weight" xvalue="260.721700"/>
+            <dimension name="space" xvalue="0"/>
+            <dimension name="grade" xvalue="-0.500000"/>
+        </location>
+        <provideFeatures state="1"/>
+        <provideGroups state="0"/>
+        <provideLib state="0"/>
+        <provideInfo state="1"/>
+    </instance>
+</designspace>

--- a/Tests/spReader_testdocs/superpolator_testdoc1_output_roundtripped.designspace
+++ b/Tests/spReader_testdocs/superpolator_testdoc1_output_roundtripped.designspace
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.0">
+  <axes>
+    <axis tag="grad" name="grade" minimum="-1" maximum="1" default="-1"/>
+    <axis tag="wdth" name="width" minimum="0" maximum="1000" default="0"/>
+    <axis tag="wght" name="weight" minimum="0" maximum="1000" default="0"/>
+    <axis tag="SPCE" name="space" minimum="0" maximum="50" default="0"/>
+  </axes>
+  <rules>
+    <rule name="width: &lt; 500.0">
+      <conditionset>
+        <condition name="width" maximum="500"/>
+        <condition name="grade" minimum="0" maximum="500"/>
+      </conditionset>
+      <sub name="I" with="I.narrow"/>
+    </rule>
+  </rules>
+  <sources>
+    <source filename="ufo/MutatorSansLightCondensed.ufo" familyname="MutatorMathTest_SourceFamilyName" stylename="">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="grade" xvalue="-0.500000"/>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="0"/>
+        <dimension name="space" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="ufo/MutatorSansBoldCondensed.ufo" familyname="MutatorMathTest_SourceFamilyName" stylename="">
+      <location>
+        <dimension name="grade" xvalue="-0.500000"/>
+        <dimension name="width" xvalue="0"/>
+        <dimension name="weight" xvalue="1000"/>
+        <dimension name="space" xvalue="0"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance familyname="MutatorMathTest_InstanceFamilyName" stylename="AWeightThatILike" filename="instances/MutatorMathTest_InstanceFamilyName-AWeightThatILike.ufo">
+      <location>
+        <dimension name="grade" xvalue="-0.500000"/>
+        <dimension name="width" xvalue="133.152174"/>
+        <dimension name="weight" xvalue="723.981097"/>
+        <dimension name="space" xvalue="0"/>
+      </location>
+      <kerning/>
+      <info/>
+      <lib>
+        <true/>
+      </lib>
+    </instance>
+    <instance familyname="MutatorMathTest_InstanceFamilyName" stylename="wdth759.79_SPCE0.00_wght260.72" filename="instances/MutatorMathTest_InstanceFamilyName-wdth759.79_SPCE0.00_wght260.72.ufo" stylemapfamilyname="StyleMappedFamily" stylemapstylename="bold">
+      <location>
+        <dimension name="grade" xvalue="-0.500000"/>
+        <dimension name="width" xvalue="500" yvalue="800"/>
+        <dimension name="weight" xvalue="260.721700"/>
+        <dimension name="space" xvalue="0"/>
+      </location>
+      <kerning/>
+      <info/>
+      <lib>
+        <true/>
+      </lib>
+    </instance>
+  </instances>
+  <lib>
+    <dict>
+      <key>com.superpolator.data</key>
+      <dict>
+        <key>expandRules</key>
+        <false/>
+        <key>horizontalPreviewAxis</key>
+        <string>width</string>
+        <key>includeLegacyRules</key>
+        <false/>
+        <key>instancefolder</key>
+        <string>instances</string>
+        <key>keepWorkFiles</key>
+        <true/>
+        <key>lineInverted</key>
+        <true/>
+        <key>lineStacked</key>
+        <string>lined</string>
+        <key>lineViewFilled</key>
+        <true/>
+        <key>outputFormatUFO</key>
+        <real>3.0</real>
+        <key>previewtext</key>
+        <string>VA</string>
+        <key>roundGeometry</key>
+        <false/>
+        <key>verticalPreviewAxis</key>
+        <string>weight</string>
+      </dict>
+    </dict>
+  </lib>
+</designspace>

--- a/Tests/tests.py
+++ b/Tests/tests.py
@@ -133,6 +133,13 @@ def _makeTestFonts(rootPath):
     f1.info.postscriptBlueScale = 0.11  # should not round
     f1.info.postscriptBlueScale = 0.22
 
+    f1.info.openTypeHheaAscender = 1036
+    f1.info.openTypeHheaDescender = -335
+    f1.info.openTypeOS2TypoAscender = 730
+    f1.info.openTypeOS2TypoDescender = -270
+    f1.info.openTypeOS2WinAscent = 1036
+    f1.info.openTypeOS2WinDescent = 335
+
     f1.groups["public.kern1.groupA"] = ['glyphOne', 'glyphTwo']
     f1.groups["public.kern2.groupB"] = ['glyphThree', 'glyphFour']
     f2.groups.update(f1.groups)


### PR DESCRIPTION
This is a parser for .sp3 documents from the macOS Superpolator app. Not all data can be converted, not everything is useful. But all the important stuff is migrated: axes, sources, instances. Some of the rules are converted as well. I've tested the converter with a wide range of .sp3 testfiles, but I expect there might be some more. 

Rather than add a sp3 parser to ufoProcessor, it is a separate Reader object that constructs a designsSpace object.

App specific data, preview preferences etc. are stored in the designspace lib. Some values are stored with Skateboard lib keys as well. 