### PR TITLE
Get the folder from the absolute path to the instance

### DIFF
--- a/Lib/ufoProcessor/__init__.py
+++ b/Lib/ufoProcessor/__init__.py
@@ -297,7 +297,7 @@ class DesignSpaceProcessor(DesignSpaceDocument):
             if instanceDescriptor.path is None:
                 continue
             font = self.makeInstance(instanceDescriptor, processRules, glyphNames=glyphNames, pairs=pairs, bend=bend)
-            folder = os.path.dirname(instanceDescriptor.path)
+            folder = os.path.dirname(os.path.abspath(instanceDescriptor.path))
             path = instanceDescriptor.path
             if not os.path.exists(folder):
                 os.makedirs(folder)


### PR DESCRIPTION
Relates to https://github.com/adobe-type-tools/afdko/issues/753

Traceback happens when `filename` is just the name of the UFO file with no leading folder path, e.g. `<instance familyname="Test" filename="Test-Result.ufo" stylename="Result">`

```
Traceback (most recent call last):
  File "/Users/msousa/Git/UFO/ufoProcessor/Lib/ufoProcessor/__init__.py", line 117, in build
    r = document.generateUFO(processRules=processRules)
  File "/Users/msousa/Git/UFO/ufoProcessor/Lib/ufoProcessor/__init__.py", line 305, in generateUFO
    os.makedirs(folder)
  File "/usr/local/bin/../Cellar/python/3.7.1/bin/../Frameworks/Python.framework/Versions/3.7/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```