### PR TITLE
Calculate instance values for com.typemytype.robofont.italicSlantOffset  #59

### DIFF
--- a/Lib/ufoProcessor/ufoOperator.py
+++ b/Lib/ufoProcessor/ufoOperator.py
@@ -1304,6 +1304,7 @@ class UFOOperator(object):
             font.info.postscriptFontName = instanceDescriptor.postScriptFontName # yikes, note the differences in capitalisation..
             font.info.styleMapFamilyName = instanceDescriptor.styleMapFamilyName
             font.info.styleMapStyleName = instanceDescriptor.styleMapStyleName
+
         # add italicSlantOffset here
         italicSlantOffsetMutator = self.getItalicSlantOffsetMutator(discreteLocation=discreteLocation)
         if italicSlantOffsetMutator:
@@ -1314,6 +1315,8 @@ class UFOOperator(object):
                 # otherwise it will always add it? Not sure?
                 font.lib[self.italicSlantOffsetLibKey] = italicSlantOffsetValue
 
+        # don't override these keys in the lib (leavinf room for more)
+        skipTheseLibKeys = [self.italicSlantOffsetLibKey]
         defaultSourceFont = self.findDefaultFont()
         # found a default source font
         if defaultSourceFont:
@@ -1321,6 +1324,7 @@ class UFOOperator(object):
             self._copyFontInfo(defaultSourceFont.info, font.info)
             # copy lib
             for key, value in defaultSourceFont.lib.items():
+                if key in skipTheseLibKeys: continue
                 font.lib[key] = value
             # copy groups
             for key, value in defaultSourceFont.groups.items():

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_0.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>1000</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_0.ufo/lib.plist
@@ -17,7 +17,7 @@
     <key>com.typemytype.robofont.generateFeaturesWithFontTools</key>
     <false/>
     <key>com.typemytype.robofont.italicSlantOffset</key>
-    <integer>0</integer>
+    <integer>100</integer>
     <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
     <integer>1</integer>
     <key>public.glyphOrder</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_1.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>1000</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_1_d2_1.ufo/lib.plist
@@ -17,7 +17,7 @@
     <key>com.typemytype.robofont.generateFeaturesWithFontTools</key>
     <false/>
     <key>com.typemytype.robofont.italicSlantOffset</key>
-    <integer>0</integer>
+    <integer>100</integer>
     <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
     <integer>1</integer>
     <key>public.glyphOrder</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_0.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>1000</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_0.ufo/lib.plist
@@ -17,7 +17,7 @@
     <key>com.typemytype.robofont.generateFeaturesWithFontTools</key>
     <false/>
     <key>com.typemytype.robofont.italicSlantOffset</key>
-    <integer>0</integer>
+    <integer>100</integer>
     <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
     <integer>1</integer>
     <key>public.glyphOrder</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_1.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>1000</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_2_d2_1.ufo/lib.plist
@@ -17,7 +17,7 @@
     <key>com.typemytype.robofont.generateFeaturesWithFontTools</key>
     <false/>
     <key>com.typemytype.robofont.italicSlantOffset</key>
-    <integer>0</integer>
+    <integer>100</integer>
     <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
     <integer>1</integer>
     <key>public.glyphOrder</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_0.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>1000</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_0.ufo/lib.plist
@@ -17,7 +17,7 @@
     <key>com.typemytype.robofont.generateFeaturesWithFontTools</key>
     <false/>
     <key>com.typemytype.robofont.italicSlantOffset</key>
-    <integer>0</integer>
+    <integer>100</integer>
     <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
     <integer>1</integer>
     <key>public.glyphOrder</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_1.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>1000</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_1000_d1_3_d2_1.ufo/lib.plist
@@ -17,7 +17,7 @@
     <key>com.typemytype.robofont.generateFeaturesWithFontTools</key>
     <false/>
     <key>com.typemytype.robofont.italicSlantOffset</key>
-    <integer>0</integer>
+    <integer>100</integer>
     <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
     <integer>1</integer>
     <key>public.glyphOrder</key>

--- a/Tests/ds5/sources/geometrySource_c_400_d1_1_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_400_d1_1_d2_0.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>0</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_400_d1_1_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_400_d1_1_d2_1.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>0</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_400_d1_2_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_400_d1_2_d2_0.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>0</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_400_d1_2_d2_1.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_400_d1_2_d2_1.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>0</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>

--- a/Tests/ds5/sources/geometrySource_c_400_d1_3_d2_0.ufo/lib.plist
+++ b/Tests/ds5/sources/geometrySource_c_400_d1_3_d2_0.ufo/lib.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.letterror.ufoOperator.libMathTestValue</key>
+    <integer>0</integer>
     <key>com.typemytype.robofont.compileSettings.autohint</key>
     <true/>
     <key>com.typemytype.robofont.compileSettings.checkOutlines</key>


### PR DESCRIPTION
Create a mutator for values in com.typemytype.robofont.italicSlantOffset. Calculate the value when making an instance UFO.
+ getItalicSlantOffsetMutator() collects the values from the relevant sources.
+ only add the value to the instance UFO lib if it is not zero. Not entirely sure about this, but it seems cleaner?
+ Lib values added to the ds5 test fonts.