### PR TITLE
Check that parent dir name is not blank before trying makedirs

### DIFF
--- a/Lib/ufoProcessor/ufoOperator.py
+++ b/Lib/ufoProcessor/ufoOperator.py
@@ -862,7 +862,7 @@ class UFOOperator(object):
                 self.logger.info(f"\t\t{os.path.basename(instanceDescriptor.path)}")
 
             instanceFolder = os.path.dirname(instanceDescriptor.path)
-            if not os.path.exists(instanceFolder):
+            if instanceFolder and not os.path.exists(instanceFolder):
                 os.makedirs(instanceFolder)
             font.save(instanceDescriptor.path)
             generatedFontPaths.append(instanceDescriptor.path)


### PR DESCRIPTION
This came up with a designspace file where the instance filename is in the same folder as the designspace. When the instance `filename` is something like `filename="samefolder.ufo"` then `instanceFolder = os.path.dirname(instanceDescriptor.path)` returns an empty string which then fails and stops the whole operation. The simplest thing seems to be checking if this is an empty string.  