### PR TITLE
Issue 66 & 65

### DIFF
--- a/Lib/ufoProcessor/ufoOperator.py
+++ b/Lib/ufoProcessor/ufoOperator.py
@@ -1368,12 +1368,9 @@ class UFOOperator(object):
         if 'public.glyphOrder' not in font.lib.keys():
             # should be the glyphorder from the default, yes?
             font.lib['public.glyphOrder'] = selectedGlyphNames
+        # remove skippable glyphs
         toSkip = self.collectSkippedGlyphs()
-        skipped = []
-        for name in selectedGlyphNames:
-            if name not in toSkip:
-                skipped.append(name)
-        selectedGlyphNames = skipped
+        selectedGlyphNames = [name for name in selectedGlyphNames if name not in toSkip]
         for glyphName in selectedGlyphNames:
             glyphMutator, unicodes = self.getGlyphMutator(glyphName, decomposeComponents=decomposeComponents, discreteLocation=discreteLocation)
             if glyphMutator is None:

--- a/Lib/ufoProcessor/ufoOperator.py
+++ b/Lib/ufoProcessor/ufoOperator.py
@@ -195,7 +195,6 @@ class UFOOperator(object):
         self.mutedAxisNames = None    # list of axisname that need to be muted
         self.strict = strict
         self.debug = debug
-        self.logger = None
         self.extrapolate = extrapolate  # if true allow extrapolation
         self.logger = None
         self.doc = None
@@ -207,17 +206,22 @@ class UFOOperator(object):
         else:
             self.doc = DesignSpaceDocument()
         if self.debug:
-            docBaseName = os.path.splitext(self.doc.path)[0]
-            logPath = f"{docBaseName}_log.txt"
-            self.logger = Logger(path=logPath, rootDirectory=None)
-            self.logger.time()
-            self.logger.info(f"## {self.doc.path}")
-            self.logger.info(f"\tUFO version: {self.ufoVersion}")
-            self.logger.info(f"\tround Geometry: {self.roundGeometry}")
-            if self.useVarlib:
-                self.logger.info(f"\tinterpolating with varlib")
-            else:
-                self.logger.info(f"\tinterpolating with mutatorMath")
+            self.startLog()
+
+    def startLog(self):
+        # so we can call it later
+        self.debug = True
+        docBaseName = os.path.splitext(self.doc.path)[0]
+        logPath = f"{docBaseName}_log.txt"
+        self.logger = Logger(path=logPath, rootDirectory=None)
+        self.logger.time()
+        self.logger.info(f"## {self.doc.path}")
+        self.logger.info(f"\tUFO version: {self.ufoVersion}")
+        self.logger.info(f"\tround Geometry: {self.roundGeometry}")
+        if self.useVarlib:
+            self.logger.info(f"\tinterpolating with varlib")
+        else:
+            self.logger.info(f"\tinterpolating with mutatorMath")
 
     def _instantiateFont(self, path):
         """ Return a instance of a font object with all the given subclasses"""
@@ -388,11 +392,11 @@ class UFOOperator(object):
 
     # loading and updating fonts
     def loadFonts(self, reload=False):
-        self.glyphNames = list({glyphname for font in self.fonts.values() for glyphname in font.keys()})
         # Load the fonts and find the default candidate based on the info flag
+        self.glyphNames = list({glyphname for font in self.fonts.values() for glyphname in font.keys()})
         if self._fontsLoaded and not reload:
             if self.debug:
-                self.logger.info("\t\t-- loadFonts requested, but fonts are loaded already and no reload requested")
+                self.logger.info("\t\t-- loadFonts called, but fonts are loaded already and no reload requested")
             return
         actions = []
         if self.debug:
@@ -1273,6 +1277,8 @@ class UFOOperator(object):
             for name in fontObj.lib.get('public.skipExportGlyphs', []):
                 if name not in names:
                     names.append(name)
+        if self.debug:
+            self.logger.info(f"collectSkippedGlyphs: {names}")
         return names
 
     def makeInstance(self, instanceDescriptor,
@@ -1289,6 +1295,7 @@ class UFOOperator(object):
         # hmm getFullDesignLocation does not support anisotropc locations?
         fullDesignLocation = instanceDescriptor.getFullDesignLocation(self.doc)
         anisotropic, continuousLocation, discreteLocation, locHorizontal, locVertical = self.getLocationType(fullDesignLocation)
+        self.loadFonts()
 
         if not self.extrapolate:
            # Axis values are in userspace, so this needs to happen before bending
@@ -1459,6 +1466,7 @@ class UFOOperator(object):
         # make one instance for this location. This is a shortcut for making an
         # instanceDescriptor. So it makes some assumptions about the font names.
         # Otherwise all the geometry will be exactly what it needs to be.
+        self.loadFonts()
         continuousLocation, discreteLocation = self.splitLocation(location)
         defaultFont = self.findDefaultFont(discreteLocation=discreteLocation)
         if defaultFont is not None:
@@ -1535,6 +1543,7 @@ class UFOOperator(object):
     # @memoize
     def makeFontProportions(self, location, bend=False, roundGeometry=True):
         """Calculate the basic font proportions for this location, to map out expectations for drawing"""
+        self.loadFonts()
         continuousLocation, discreteLocation = self.splitLocation(location)
         infoMutator = self.getInfoMutator(discreteLocation=discreteLocation)
         data = dict(unitsPerEm=1000, ascender=750, descender=-250, xHeight=500)
@@ -1568,8 +1577,8 @@ class UFOOperator(object):
 
         Returns: a mathglyph, results are cached
         """
+        self.loadFonts()
         continuousLocation, discreteLocation = self.splitLocation(location)
-
         bend=False  #
         if not self.extrapolate:
             # Axis values are in userspace, so this needs to happen *after* clipping.
@@ -1620,6 +1629,7 @@ class UFOOperator(object):
         """
         if self.debug:
             self.logger.info(f"\t\t\tmakeOneInfo for {location}")
+        self.loadFonts()
         bend = False
         anisotropic, continuousLocation, discreteLocation, locHorizontal, locVertical = self.getLocationType(location)
         # so we can take the math object that comes out of the calculation
@@ -1650,6 +1660,7 @@ class UFOOperator(object):
         """
         if self.debug:
             self.logger.info(f"\t\t\tmakeOneKerning for {location}")
+        self.loadFonts()
         bend = False
         kerningObject = None
         anisotropic, continuousLocation, discreteLocation, locHorizontal, locVertical = self.getLocationType(location)

--- a/Lib/ufoProcessor/ufoOperator.py
+++ b/Lib/ufoProcessor/ufoOperator.py
@@ -1266,6 +1266,15 @@ class UFOOperator(object):
             locHorizontal, locVertical = self.splitAnisotropic(loc)
         return anisotropic, continuousLocation, discreteLocation, locHorizontal, locVertical
 
+    def collectSkippedGlyphs(self):
+        # return a list of all the glyphnames listed in public.skipExportGlyphs
+        names = []
+        for fontPath, fontObj in self.fonts.items():
+            for name in fontObj.lib.get('public.skipExportGlyphs', []):
+                if name not in names:
+                    names.append(name)
+        return names
+
     def makeInstance(self, instanceDescriptor,
             doRules=None,
             glyphNames=None,
@@ -1359,7 +1368,12 @@ class UFOOperator(object):
         if 'public.glyphOrder' not in font.lib.keys():
             # should be the glyphorder from the default, yes?
             font.lib['public.glyphOrder'] = selectedGlyphNames
-
+        toSkip = self.collectSkippedGlyphs()
+        skipped = []
+        for name in selectedGlyphNames:
+            if name not in toSkip:
+                skipped.append(name)
+        selectedGlyphNames = skipped
         for glyphName in selectedGlyphNames:
             glyphMutator, unicodes = self.getGlyphMutator(glyphName, decomposeComponents=decomposeComponents, discreteLocation=discreteLocation)
             if glyphMutator is None:
@@ -1853,3 +1867,5 @@ if __name__ == "__main__":
 
     for instanceDescriptor in doc.instances:
         print('path for instancedescriptor', doc.pathForInstance(instanceDescriptor))
+
+    doc.collectSkippedGlyphs()


### PR DESCRIPTION
+ Respect the glyphnames listed in `public.skipExportGlyphs` when making UFO. To be clear: glyphNames in public.skipExportGlyphs will **not** be generated. (#66)
+ self.loadFonts() added to `generateUFOs(), makeInstance(), makeOneInstance(), makeFontProportions(), makeOneGlyph(), makeOneInfo(), makeOneKerning()`. Because it is not always clear whether the fonts were indeed loaded. (#65)
+ Add a method `startLog()` to be called when we want to see the log after starting without debug.
